### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "1.0.0"
 license = "MIT"
 edition = "2021"
 authors = ["Tim Plotnikov"]
-homepage = "https://github.com/0xtmphey/signature-verifier"
+repository = "https://github.com/0xtmphey/signature-verifier"
 keywords = ["crypto", "blockchain", "solana", "ethereum"]
 
 [features]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).